### PR TITLE
Corrected trunk URL with new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Then check your browser:
 ## Dependencies
 
 - `rust`: https://rustup.rs/
-- `trunk`: To install `trunk`, visit the project page: https://trunkrs.dev/
+- `trunk`: To install `trunk`, visit the project page: https://trunk-rs.github.io/trunk/
 
 All project dependencies have been updated in september 16, 2025.
 


### PR DESCRIPTION
Old URL would lead to a Casino website. Now it is corrected with the most recent project's page URL